### PR TITLE
removing unwanted inconsistent aws dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
 		<dropwizard.version>3.5.1</dropwizard.version>
 		<vertx-concurrent.version>1.0.0</vertx-concurrent.version>
 		<kie.version>7.1.0.Final</kie.version>
-
 	</properties>
 
 	<distributionManagement>
@@ -189,11 +188,6 @@
 			<artifactId>vavr</artifactId>
 			<version>0.9.1</version>
 		</dependency>
-<dependency>
-    <groupId>org.apache.httpcomponents</groupId>
-    <artifactId>httpclient</artifactId>
-    <version>4.3.3</version>
-</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Fixed aws dependency consistency issue in 2 projects :
1) Qwanda_Utils
2) Genny-rules
PR given in both services.

In genny-rules, I removed the dependency of "apache-httpclient" due to following reasons : 
1) Genny-rules had a very old version of apache-httpclient. 
2) Also this dependency is unnecessary in genny-rules since qwanda-utils already has it.